### PR TITLE
Use dynamic table names when building SQL queries.

### DIFF
--- a/core/functions.php
+++ b/core/functions.php
@@ -341,8 +341,6 @@ class TaskBreakerCore {
 
 		$db = TaskBreaker::wpdb();
 
-		$tbl_posts = $db->prefix . 'posts';
-		$tbl_groups = $db->prefix . 'bp_groups';
 		$user_groups = groups_get_user_groups( $user_id );
 
 		if ( empty( $user_groups['groups'] ) ) {
@@ -357,14 +355,16 @@ class TaskBreakerCore {
 
 		$offset = ( $paged - 1 ) * $limit;
 
+		$bp = buddypress();
+
 		$user_public_projects = $db->get_results(
 			$db->prepare(
-				"SELECT SQL_CALC_FOUND_ROWS post.ID, post.post_content, 
-						post.post_title, post_meta.meta_value as group_id, bp_group.status 
-					FROM wp_posts as post 
-					INNER JOIN wp_postmeta as post_meta on post.ID = post_meta.post_id 
-					INNER JOIN wp_bp_groups as bp_group ON bp_group.id = post_meta.meta_value 
-					WHERE post_meta.meta_key = 'task_breaker_project_group_id' 
+				"SELECT SQL_CALC_FOUND_ROWS post.ID, post.post_content,
+						post.post_title, post_meta.meta_value as group_id, bp_group.status
+					FROM {$db->posts} as post
+					INNER JOIN {$db->postmeta} as post_meta on post.ID = post_meta.post_id
+					INNER JOIN {$bp->groups->table_name} as bp_group ON bp_group.id = post_meta.meta_value
+					WHERE post_meta.meta_key = 'task_breaker_project_group_id'
 						  and bp_group.id IN (" . esc_sql( implode( ',', $user_groups['groups'] ) ) . ')
                     ORDER BY post.ID DESC
                     LIMIT %d OFFSET %d;'
@@ -402,9 +402,6 @@ class TaskBreakerCore {
 
 		$db = TaskBreaker::wpdb();
 
-		$tbl_posts = $db->prefix . 'posts';
-		$tbl_groups = $db->prefix . 'bp_groups';
-
 		$user_id = bp_displayed_user_id();
 		$user_groups = groups_get_user_groups( $user_id );
 
@@ -420,14 +417,16 @@ class TaskBreakerCore {
 
 		$offset = ( $paged - 1 ) * $limit;
 
+		$bp = buddypress();
+
 		$user_public_projects = $db->get_results(
 			$db->prepare(
-				"SELECT SQL_CALC_FOUND_ROWS post.ID, post.post_content, 
-						post.post_title, post_meta.meta_value as group_id, bp_group.status 
-					FROM wp_posts as post 
-					INNER JOIN wp_postmeta as post_meta on post.ID = post_meta.post_id 
-					INNER JOIN wp_bp_groups as bp_group ON bp_group.id = post_meta.meta_value 
-					WHERE post_meta.meta_key = 'task_breaker_project_group_id' 
+				"SELECT SQL_CALC_FOUND_ROWS post.ID, post.post_content,
+						post.post_title, post_meta.meta_value as group_id, bp_group.status
+					FROM {$db->posts} as post
+					INNER JOIN {$db->postmeta} as post_meta on post.ID = post_meta.post_id
+					INNER JOIN {$bp->groups->table_name} as bp_group ON bp_group.id = post_meta.meta_value
+					WHERE post_meta.meta_key = 'task_breaker_project_group_id'
 						  and bp_group.status = 'public'
 						  and bp_group.id IN (" . esc_sql( implode( ',', $user_groups['groups'] ) ) . ')
                     ORDER BY post.ID DESC
@@ -468,9 +467,6 @@ class TaskBreakerCore {
 
 		$db = TaskBreaker::wpdb();
 
-		$tbl_posts = $db->prefix . 'posts';
-		$tbl_groups = $db->prefix . 'bp_groups';
-
 		$limit = TASK_BREAKER_PROJECT_LIMIT;
 
 		$paged = filter_input( INPUT_GET, 'paged', FILTER_SANITIZE_NUMBER_INT );
@@ -479,10 +475,12 @@ class TaskBreakerCore {
 
 		$offset = ( $paged - 1 ) * $limit;
 
+		$bp = buddypress();
+
 		$group_projects = $db->get_results(
 			$db->prepare(
-				"SELECT SQL_CALC_FOUND_ROWS post.ID, post.post_title, post_meta.meta_value as group_id FROM wp_posts as post
-					INNER JOIN wp_postmeta as post_meta on post.ID = post_meta.post_id
+				"SELECT SQL_CALC_FOUND_ROWS post.ID, post.post_title, post_meta.meta_value as group_id FROM {$db->posts} as post
+					INNER JOIN {$db->postmeta} as post_meta on post.ID = post_meta.post_id
 					WHERE post_meta.meta_key = 'task_breaker_project_group_id'
 					AND post_meta.meta_value = %s
 					ORDER BY post.ID DESC


### PR DESCRIPTION
Thanks for the useful plugin!

In the most recent release, it looks like you rewrite some SQL queries, and in the process, you started to make the SQL table names dynamic. But it looks like you didn't fully follow through on that. As a result, group-project and other queries stopped working on installations with non-standard table prefixes.

Your technique for building the table names `$tbl_name = $db->prefix . 'posts'` is fine, but it doesn't directly parallel the style used in BP and WP. For better readability, I've used the `$db->postmeta` and `$bp->groups->table_name` format instead in the areas where the table names were broken altogether. Feel free to change back to your preferred style if you'd prefer. I didn't include stylistic changes to any table names that are working properly.